### PR TITLE
Update Whisper Model to Version 20240930

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ There are five model sizes, four with English-only versions, offering speed and 
 | small  |   244 M    |     `small.en`     |      `small`       |     ~2 GB     |      ~6x       |
 | medium |   769 M    |    `medium.en`     |      `medium`      |     ~5 GB     |      ~2x       |
 | large  |   1550 M   |        N/A         |      `large`       |    ~10 GB     |       1x       |
+| turbo  |   809 M    |        N/A         |      `turbo`       |     ~6 GB     |      ~8x       |
 
 The `.en` models for English-only applications tend to perform better, especially for the `tiny.en` and `base.en` models. We observed that the difference becomes less significant for the `small.en` and `medium.en` models.
 

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,22 @@
+version: "3.8"
+services:
+  server:
+    build:
+      context: ./server
+      dockerfile: ./Dockerfile
+    ports:
+      - 80:80
+    volumes:
+      - models:/root/.cache/whisper
+      - db:/app/db
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+volumes:
+  models:
+  db:

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,11 +1,10 @@
-version: "3.8"
 services:
   server:
     build:
       context: ./server
       dockerfile: ./Dockerfile
     ports:
-      - 80:80
+      - 8080:80
     volumes:
       - models:/root/.cache/whisper
       - db:/app/db

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -4,7 +4,7 @@ services:
       context: ./server
       dockerfile: ./Dockerfile
     ports:
-      - 8080:80
+      - 80:80
     volumes:
       - models:/root/.cache/whisper
       - db:/app/db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   server:
     build:

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8
+FROM python:3.9
 
 WORKDIR /app/
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,3 @@
-torch==2.0.0
+torch==2.6.0
 ffmpeg-python==0.2.0
-openai-whisper==20230314
+openai-whisper==20240930

--- a/server/src/routes/model.py
+++ b/server/src/routes/model.py
@@ -152,9 +152,9 @@ async def transcribe_audio(model_name: str,
         
     filename = file.filename.split(".")[0]
     file_out = io.StringIO()
-    eval(f"Write{format.upper()}(ResultWriter).write_result(result, file=file_out)")
+    eval(f"whisper.utils.Write{format.upper()}('.').write_result(result, file=file_out)")
     file_out.seek(0)
-
+    
     return StreamingResponse(file_out,
                              media_type = "text/plain",
                              headers = {


### PR DESCRIPTION
The [20240930](https://github.com/openai/whisper/tree/v20240930) release of Whisper adds an additional model, 'turbo'. Updating `requirements.txt` was enough to get the microservice to be able to download and use the model. 

However, after updating, I noticed requesting anything besides the default JSON file with the `/models/{model}/transcribe` route would cause an Internal Server Error. I changed the line used to invoke the whisper writers and requesting non-JSON output seems to work now. 

I also added a docker-compose file that passes through an Nvidia GPU, as an example for anyone else that may want to use these docker-compose files as a starting point.

Thanks for creating this repository, this was perfect for another project I was working on.
